### PR TITLE
fix: dont cache current buffer

### DIFF
--- a/lua/goplements/init.lua
+++ b/lua/goplements/init.lua
@@ -118,11 +118,18 @@ M.implementation_callback = function(fcache, result, publish_names)
       local impl_end = impl.range["end"].character
 
       -- Read the line of the implementation to get the name
-      local file = vim.uri_to_fname(uri)
-      local data = fcache[file]
-      if not data then
-        data = vim.fn.readfile(file)
-        fcache[file] = data
+      local data = {}
+
+      local buf = vim.uri_to_bufnr(uri)
+      if vim.api.nvim_buf_is_loaded(buf) then
+        data = vim.api.nvim_buf_get_lines(buf, 0, impl_line + 1, false)
+      else
+        local file = vim.uri_to_fname(uri)
+        data = fcache[file]
+        if not data then
+          data = vim.fn.readfile(file)
+          fcache[file] = data
+        end
       end
 
       local package_name = ""

--- a/vim.toml
+++ b/vim.toml
@@ -17,3 +17,5 @@ any = true
 [it]
 any = true
 
+[before_each]
+any = true


### PR DESCRIPTION
## Description

The bug happened because Goplements cached any file to avoid reading it twice from the filesystem.
That made the data invalid when the file is in a loaded buffer that was modified and not yet written to the filesystem.

The fix reads file's data from buffers if they are loaded and only read from the filesystem unloaded files.

## Related Issue(s)

https://github.com/maxandron/goplements.nvim/issues/4

